### PR TITLE
Fix real bugs found by actually running the test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ logs/
 wandb
 outputs/
 monitor_logs/
+.venv-test/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,3 +100,9 @@ ignore = [
 [tool.ruff.lint.pyupgrade]
 # Preserve types, even if a file imports `from __future__ import annotations`.
 keep-runtime-typing = true
+
+[tool.pytest.ini_options]
+markers = [
+    "network: requires internet access (e.g. HuggingFace model download)",
+]
+addopts = "-ra"

--- a/scripts/eval_representations.py
+++ b/scripts/eval_representations.py
@@ -26,6 +26,7 @@ from datasets import load_dataset
 from transformers import AutoTokenizer, PreTrainedTokenizer
 
 from src.common.config import LANGJEPAConfig
+from src.common.stats import spearman_rho
 from src.decoder.concept_extractor import ConceptExtractor
 from src.encoder.models import TextTransformer
 
@@ -68,20 +69,6 @@ def _embed_batch(
     return torch.cat(out, dim=0)
 
 
-def _spearman(a: list[float], b: list[float]) -> float:
-    """Spearman ρ via Pearson on ranks. Ties handled via argsort-of-argsort."""
-    at = torch.tensor(a, dtype=torch.float64)
-    bt = torch.tensor(b, dtype=torch.float64)
-    a_rank = torch.argsort(torch.argsort(at)).double()
-    b_rank = torch.argsort(torch.argsort(bt)).double()
-    a_rank -= a_rank.mean()
-    b_rank -= b_rank.mean()
-    denom = (a_rank.norm() * b_rank.norm()).item()
-    if denom == 0:
-        return 0.0
-    return float((a_rank @ b_rank).item() / denom)
-
-
 def sts_benchmark(
     extractor: ConceptExtractor,
     tokenizer: PreTrainedTokenizer,
@@ -98,7 +85,7 @@ def sts_benchmark(
     c2 = _embed_batch(extractor, tokenizer, s2, device, max_length, batch_size)
     sims = F.cosine_similarity(c1, c2, dim=-1).tolist()
 
-    return {"sts_spearman": _spearman(sims, labels), "n_pairs": float(len(labels))}
+    return {"sts_spearman": spearman_rho(sims, labels), "n_pairs": float(len(labels))}
 
 
 def linear_probe_sst2(

--- a/src/common/stats.py
+++ b/src/common/stats.py
@@ -1,0 +1,29 @@
+"""Small statistics utilities used by evaluation and monitoring.
+
+Kept dependency-light (only torch) so tests don't need to transitively pull in
+the full evaluation stack (`datasets`, `rouge_score`, etc.).
+"""
+from __future__ import annotations
+
+import torch
+
+
+def spearman_rho(a: list[float], b: list[float]) -> float:
+    """Spearman ρ via Pearson correlation on ranks.
+
+    Degenerate case: if either input has zero variance (all values equal), ρ
+    is undefined — we return 0.0. Ties are broken by argsort-of-argsort; for
+    data with heavy ties, prefer scipy.stats.spearmanr.
+    """
+    at = torch.tensor(a, dtype=torch.float64)
+    bt = torch.tensor(b, dtype=torch.float64)
+    if at.numel() < 2 or at.std() == 0 or bt.std() == 0:
+        return 0.0
+    a_rank = torch.argsort(torch.argsort(at)).double()
+    b_rank = torch.argsort(torch.argsort(bt)).double()
+    a_rank -= a_rank.mean()
+    b_rank -= b_rank.mean()
+    denom = (a_rank.norm() * b_rank.norm()).item()
+    if denom == 0:
+        return 0.0
+    return float((a_rank @ b_rank).item() / denom)

--- a/src/decoder/models.py
+++ b/src/decoder/models.py
@@ -65,12 +65,14 @@ def _top_k_top_p_filter(
         sorted_logits, sorted_idx = torch.sort(logits, descending=True, dim=-1)
         cum = F.softmax(sorted_logits, dim=-1).cumsum(dim=-1)
         remove = cum > top_p
-        # Always keep the top token.
-        remove[..., 0] = False
-        # Shift right so we remove the token AFTER the threshold is crossed.
+        # Shift right so the token that CROSSES the threshold is still kept,
+        # then unconditionally keep the top token.
         remove[..., 1:] = remove[..., :-1].clone()
+        remove[..., 0] = False
         sorted_logits = sorted_logits.masked_fill(remove, float("-inf"))
-        logits = torch.zeros_like(logits).scatter(-1, sorted_idx, sorted_logits)
+        logits = torch.full_like(logits, float("-inf")).scatter(
+            -1, sorted_idx, sorted_logits
+        )
     return logits
 
 

--- a/tests/test_spearman.py
+++ b/tests/test_spearman.py
@@ -1,25 +1,21 @@
-import sys
-
-# Import the internal Spearman implementation used by eval_representations.
-sys.path.insert(0, "scripts")
-from eval_representations import _spearman  # noqa: E402
+from src.common.stats import spearman_rho
 
 
 def test_spearman_perfect_positive():
-    assert _spearman([1, 2, 3, 4, 5], [10, 20, 30, 40, 50]) > 0.999
+    assert spearman_rho([1, 2, 3, 4, 5], [10, 20, 30, 40, 50]) > 0.999
 
 
 def test_spearman_perfect_negative():
-    assert _spearman([1, 2, 3, 4, 5], [50, 40, 30, 20, 10]) < -0.999
+    assert spearman_rho([1, 2, 3, 4, 5], [50, 40, 30, 20, 10]) < -0.999
 
 
 def test_spearman_is_rank_invariant():
-    # Monotonic transformation shouldn't change Spearman.
+    # Any monotonic transformation leaves Spearman ρ unchanged.
     a = [1, 2, 3, 4, 5]
-    b = [1.0, 4.0, 9.0, 16.0, 25.0]  # b = a^2
-    assert _spearman(a, b) > 0.999
+    b = [1.0, 4.0, 9.0, 16.0, 25.0]
+    assert spearman_rho(a, b) > 0.999
 
 
 def test_spearman_degenerate_inputs():
-    # All-equal input has zero variance; _spearman should return 0 not NaN.
-    assert _spearman([1, 1, 1, 1], [1, 2, 3, 4]) == 0.0
+    # Zero variance on one side should return 0.0, not NaN.
+    assert spearman_rho([1, 1, 1, 1], [1, 2, 3, 4]) == 0.0


### PR DESCRIPTION
Three issues:

1. _top_k_top_p_filter masked removed tokens to 0 instead of -inf, because the sorted_logits-with-inf tensor was scattered into a zeros_like base. Also the shift-then-set-top-to-False ordering was inverted, which kept one extra token at the threshold. Fix: scatter into a full_like(-inf) base, and shift first so the threshold-crossing token is kept and only the top is force-kept.

2. spearman_rho returned ~1.0 instead of 0.0 on all-equal inputs because argsort-of-argsort of a constant array still produces [0, 1, ..., n-1], which has nonzero rank variance. Added an up-front zero-variance check.

3. tests/test_spearman.py imported _spearman from a script module (scripts/eval_representations.py), which module-level-imports `datasets`. The test couldn't run without the heavy eval dependency installed. Fix: extracted spearman_rho into src/common/stats.py (stdlib + torch only). Script and test both import from there.

Also:
- Register the "network" pytest marker in pyproject.toml so `pytest -m "not network"` doesn't warn.
- .gitignore the local test venv.

Tests: 30 passed, 2 deselected (network) on Python 3.13 with torch 2.11 CPU.